### PR TITLE
xbeach expects booleans to be 0-1

### DIFF
--- a/src/rompy_xbeach/data/boundary/base.py
+++ b/src/rompy_xbeach/data/boundary/base.py
@@ -221,6 +221,12 @@ class WaveBoundaryParams(RompyBaseModel):
         ),
     )
 
+    @model_serializer(mode="wrap")
+    def _serialize_xbeach_params(self, handler) -> dict[str, Any]:
+        """Convert booleans to integers for XBeach params.txt compatibility."""
+        data = handler(self)
+        return {k: int(v) if isinstance(v, bool) else v for k, v in data.items()}
+
 
 class SpectralWaveBoundaryParams(WaveBoundaryParams):
     """Spectral wave boundary condition parameters.

--- a/tests/test_physics_extended.py
+++ b/tests/test_physics_extended.py
@@ -107,14 +107,19 @@ def test_wave_boundary_params():
         wbcScaleEnergy=True,
         cyclicdiradjust=False,
     )
+    assert wave_bc.bclwonly is True
+    assert wave_bc.wbcRemoveStokes is False
+    assert wave_bc.wbcScaleEnergy is True
+    assert wave_bc.cyclicdiradjust is False
+
     data = wave_bc.model_dump(exclude_none=True)
     assert data["nmax"] == 0.7
     assert data["wbcevarreduce"] == 0.8
-    assert data["bclwonly"] is True
+    assert data["bclwonly"] == 1
     assert data["swkhmin"] == 0.01
-    assert data["wbcRemoveStokes"] is False
-    assert data["wbcScaleEnergy"] is True
-    assert data["cyclicdiradjust"] is False
+    assert data["wbcRemoveStokes"] == 0
+    assert data["wbcScaleEnergy"] == 1
+    assert data["cyclicdiradjust"] == 0
 
 
 def test_nonh_wavemodel():

--- a/tests/test_wbc_hierarchy.py
+++ b/tests/test_wbc_hierarchy.py
@@ -157,7 +157,7 @@ def test_serialization_base():
     """Test serialization of base WaveBoundaryParams."""
     wbc = WaveBoundaryParams(nmax=0.8, wbcScaleEnergy=True, taper=100.0)
     params = wbc.model_dump(exclude_none=True)
-    assert params == {"nmax": 0.8, "wbcScaleEnergy": True, "taper": 100.0}
+    assert params == {"nmax": 0.8, "wbcScaleEnergy": 1, "taper": 100.0}
 
 
 def test_serialization_spectral():
@@ -173,7 +173,7 @@ def test_serialization_spectral():
         "nmax": 0.8,
         "rt": 3600.0,
         "dtbc": 1.0,
-        "random": True,
+        "random": 1,
     }
 
 


### PR DESCRIPTION
we were seeing errors random= True when I think xbeach wants random = 1 
> Cause: In the refactor, random moved from top-level Config (which had a field_serializer converting bool → int) onto WaveBoundaryParams, which only inherits RompyBaseModel, not XBeachBaseModel. So model_dump() kept Python True, and the Jinja template rendered it literally as True.