### PR TITLE
Convert booleans to 0/1 at the Config aggregation chokepoint

### DIFF
--- a/src/rompy_xbeach/config.py
+++ b/src/rompy_xbeach/config.py
@@ -263,4 +263,11 @@ class Config(XBeachBaseConfig):
         # MPI configuration
         self._params.update(self.mpi.get(staging_dir))
 
+        # XBeach expects booleans as 0/1. Normalise here, at the single point where
+        # all component params are aggregated, so data interfaces (wave, wind, tide)
+        # that don't go through the XBeachBaseModel serializer are also covered.
+        self._params = {
+            k: int(v) if isinstance(v, bool) else v for k, v in self._params.items()
+        }
+
         return self._params

--- a/tests/test_boundary.py
+++ b/tests/test_boundary.py
@@ -504,3 +504,42 @@ def test_boundary_station_spectra_swan_filelist(
         # Assert swan file defined in bcfile
         ds = read_swan(filename)
         assert hasattr(ds, "spec")
+
+
+# =====================================================================================
+# Data-interface field leakage guard
+# =====================================================================================
+def test_data_interface_fields_not_serialized(tmp_path, source_file, grid, time):
+    """Data interface fields must not leak into the XBeach params dict.
+
+    Concrete data-driven boundary classes inherit many fields from the rompy data
+    interfaces (source, coords, etc.). These must be stripped from the serialized
+    params (by BoundaryBase._serialize), otherwise they end up in params.txt.
+    """
+    wb = BoundaryStationParamJons(
+        source=source_file,
+        coords=dict(s="seapoint", x="longitude", y="latitude", t="time"),
+        filelist=False,
+        hm0_var="phs1",
+        tp_var="ptp1",
+        mainang_var="pdp1",
+        gammajsp_var="ppe1",
+        dspr_var="pspr1",
+        wbcScaleEnergy=True,
+    )
+    boundary_spec = wb.get(destdir=tmp_path, grid=grid, time=time)
+    leaked = {
+        "source",
+        "coords",
+        "location",
+        "variables",
+        "time_buffer",
+        "buffer",
+        "crop_data",
+        "filter",
+        "sel_method",
+        "sel_method_kwargs",
+    } & set(boundary_spec)
+    assert not leaked, f"Data interface fields leaked into params: {sorted(leaked)}"
+    # Wave parameters must still be present
+    assert "wbcScaleEnergy" in boundary_spec

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,3 +63,32 @@ def test_model_generate(kwargs, tmp_path):
     )
     model.generate()
     assert (tmp_path / model.run_id / "params.txt").is_file()
+
+
+def test_boolean_params_rendered_as_integers(kwargs, tmp_path):
+    """Booleans must be rendered as 0/1 in params.txt, not Python True/False.
+
+    Wave boundary classes don't go through the XBeachBaseModel serializer, so the
+    boolean->int conversion is applied at the Config aggregation chokepoint. This
+    asserts the conversion reaches the rendered params.txt for a wave boundary
+    boolean parameter.
+    """
+    import copy
+
+    kwargs = copy.deepcopy(kwargs)
+    kwargs["input"]["wave"]["wbcScaleEnergy"] = True
+    kwargs["input"]["wave"]["wbcRemoveStokes"] = False
+    config = Config(**kwargs)
+    model = ModelRun(
+        run_id="test_bools",
+        output_dir=str(tmp_path),
+        config=config,
+        period=TimeRange(start="2023-01-01T00", end="2023-01-01T12", interval="1h"),
+    )
+    model.generate()
+    params_txt = (tmp_path / model.run_id / "params.txt").read_text()
+    assert "wbcScaleEnergy = 1" in params_txt
+    assert "wbcRemoveStokes = 0" in params_txt
+    # No Python-style booleans should appear anywhere in the rendered file
+    assert "= True" not in params_txt
+    assert "= False" not in params_txt


### PR DESCRIPTION
## Summary

XBeach's `params.txt` expects boolean switches as `1`/`0`. Wave boundary classes (`WaveBoundaryParams` and subclasses) inherit from `RompyBaseModel` rather than `XBeachBaseModel`, so they bypass the existing `bool`→`int` serializer in `XBeachBaseModel`. Their boolean parameters (`wbcScaleEnergy`, `wbcRemoveStokes`, `bclwonly`, `cyclicdiradjust`, …) were therefore rendered as Python `True`/`False`, which XBeach cannot parse.

This is an alternative fix to #40, which addressed the same real bug but introduced a regression (see below).

## Why not a per-class serializer (as in #40)

#40 adds a second `@model_serializer` (`_serialize_xbeach_params`) on `WaveBoundaryParams`. But `BoundaryBase` already defines a `@model_serializer` (`_serialize`) whose job is to strip data-interface fields (`source`, `coords`, `location`, `variables`, …) inherited from the rompy data interfaces.

Pydantic v2 allows **only one** model serializer per model. When two exist in the MRO it silently keeps the one **earliest in the MRO** — which is `WaveBoundaryParams._serialize_xbeach_params`. On every concrete data-driven boundary class (`BoundaryStationParamJons`, `BoundaryGridParamJons`, …) this **shadows `BoundaryBase._serialize` and disables the field filtering**, leaking `source`/`coords`/etc. into `params.txt`.

## This approach

Normalise booleans once in `Config.__call__`, at the single point where all component params are aggregated. This covers wave, wind and tide data interfaces uniformly and leaves the existing serializers (including `BoundaryBase._serialize`) untouched.

## Tests

- `test_boolean_params_rendered_as_integers` — booleans reach `params.txt` as `0`/`1`
- `test_data_interface_fields_not_serialized` — guards against the field-leakage regression in concrete data-driven boundary classes

Full suite: 265 passed.